### PR TITLE
fix: rename package from pockertracker to pokertracker

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -86,9 +86,9 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
     compileSdk rootProject.ext.compileSdkVersion
 
-    namespace 'com.yonatantseitlin.pockertracker'
+    namespace 'com.yonatantseitlin.pokertracker'
     defaultConfig {
-        applicationId 'com.yonatantseitlin.pockertracker'
+        applicationId 'com.yonatantseitlin.pokertracker'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -22,7 +22,7 @@
           }
         },
         {
-          "client_id": "46648411194-jngpfko87lm9edc9f9scig1n6thg1h9j.apps.googleusercontent.com",
+          "client_id": "46648411194-u61cupaga1rti7fq2bfmsli3e0hjvh34.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
@@ -51,7 +51,7 @@
     },
     {
       "client_info": {
-        "mobilesdk_app_id": "1:46648411194:android:eb974409a0cb5bf0766103",
+        "mobilesdk_app_id": "1:46648411194:android:a4e5ef0a348e9ba7766103",
         "android_client_info": {
           "package_name": "com.yonatantseitlin.pokertracker"
         }

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -48,6 +48,42 @@
           ]
         }
       }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:46648411194:android:eb974409a0cb5bf0766103",
+        "android_client_info": {
+          "package_name": "com.yonatantseitlin.pokertracker"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "46648411194-u61cupaga1rti7fq2bfmsli3e0hjvh34.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBYJly67cRmR972TblBFIJ9DNgGlae8cYc"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "46648411194-jngpfko87lm9edc9f9scig1n6thg1h9j.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "46648411194-e01krl1j36r8m2frp9v1v9aqs603va2u.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.yonatantseitlin.pockertracker"
+              }
+            }
+          ]
+        }
+      }
     }
   ],
   "configuration_version": "1"

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -7,50 +7,6 @@
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:46648411194:android:b03e907c57a9bcbf766103",
-        "android_client_info": {
-          "package_name": "com.yonatantseitlin.pockertracker"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "46648411194-e3ohsq6d16ucck2eced2srot58ja0s9u.apps.googleusercontent.com",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "com.yonatantseitlin.pockertracker",
-            "certificate_hash": "4487e9272cc49cee66ddecf987727fb85c4c92b4"
-          }
-        },
-        {
-          "client_id": "46648411194-u61cupaga1rti7fq2bfmsli3e0hjvh34.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyBYJly67cRmR972TblBFIJ9DNgGlae8cYc"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "46648411194-jngpfko87lm9edc9f9scig1n6thg1h9j.apps.googleusercontent.com",
-              "client_type": 3
-            },
-            {
-              "client_id": "46648411194-e01krl1j36r8m2frp9v1v9aqs603va2u.apps.googleusercontent.com",
-              "client_type": 2,
-              "ios_info": {
-                "bundle_id": "com.yonatantseitlin.pockertracker"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "client_info": {
         "mobilesdk_app_id": "1:46648411194:android:a4e5ef0a348e9ba7766103",
         "android_client_info": {
           "package_name": "com.yonatantseitlin.pokertracker"
@@ -78,7 +34,7 @@
               "client_id": "46648411194-e01krl1j36r8m2frp9v1v9aqs603va2u.apps.googleusercontent.com",
               "client_type": 2,
               "ios_info": {
-                "bundle_id": "com.yonatantseitlin.pockertracker"
+                "bundle_id": "com.yonatantseitlin.pokertracker"
               }
             }
           ]

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
         <data android:scheme="myapp"/>
-        <data android:scheme="com.yonatantseitlin.pockertracker"/>
+        <data android:scheme="com.yonatantseitlin.pokertracker"/>
       </intent-filter>
     </activity>
   </application>

--- a/android/app/src/main/java/com/yonatantseitlin/pokertracker/MainActivity.kt
+++ b/android/app/src/main/java/com/yonatantseitlin/pokertracker/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.yonatantseitlin.pockertracker
+package com.yonatantseitlin.pokertracker
 import expo.modules.splashscreen.SplashScreenManager
 
 import android.os.Build

--- a/android/app/src/main/java/com/yonatantseitlin/pokertracker/MainApplication.kt
+++ b/android/app/src/main/java/com/yonatantseitlin/pokertracker/MainApplication.kt
@@ -1,4 +1,4 @@
-package com.yonatantseitlin.pockertracker
+package com.yonatantseitlin.pokertracker
 
 import android.app.Application
 import android.content.res.Configuration

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "sdkVersion": "54.0.0",
     "name": "Poker Tracker",
-    "slug": "pocker-tracker",
+    "slug": "poker-tracker",
     "version": "1.2.0",
     "orientation": "portrait",
     "icon": "./assets/images/pokerLogo.png",

--- a/app.json
+++ b/app.json
@@ -6,12 +6,12 @@
     "version": "1.2.0",
     "orientation": "portrait",
     "icon": "./assets/images/pokerLogo.png",
-    "scheme": "com.yonatantseitlin.pockertracker",
+    "scheme": "com.yonatantseitlin.pokertracker",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.yonatantseitlin.pockertracker",
+      "bundleIdentifier": "com.yonatantseitlin.pokertracker",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       }
@@ -21,7 +21,7 @@
         "foregroundImage": "./assets/images/pokerLogo.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.yonatantseitlin.pockertracker",
+      "package": "com.yonatantseitlin.pokertracker",
       "googleServicesFile": "./android/app/google-services.json"
     },
     "web": {

--- a/config/google-services.json
+++ b/config/google-services.json
@@ -48,6 +48,42 @@
           ]
         }
       }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:46648411194:android:eb974409a0cb5bf0766103",
+        "android_client_info": {
+          "package_name": "com.yonatantseitlin.pokertracker"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "46648411194-u61cupaga1rti7fq2bfmsli3e0hjvh34.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBYJly67cRmR972TblBFIJ9DNgGlae8cYc"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "46648411194-jngpfko87lm9edc9f9scig1n6thg1h9j.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "46648411194-e01krl1j36r8m2frp9v1v9aqs603va2u.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.yonatantseitlin.pockertracker"
+              }
+            }
+          ]
+        }
+      }
     }
   ],
   "configuration_version": "1"

--- a/config/google-services.json
+++ b/config/google-services.json
@@ -7,50 +7,6 @@
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:46648411194:android:b03e907c57a9bcbf766103",
-        "android_client_info": {
-          "package_name": "com.yonatantseitlin.pockertracker"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "46648411194-e3ohsq6d16ucck2eced2srot58ja0s9u.apps.googleusercontent.com",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "com.yonatantseitlin.pockertracker",
-            "certificate_hash": "4487e9272cc49cee66ddecf987727fb85c4c92b4"
-          }
-        },
-        {
-          "client_id": "46648411194-u61cupaga1rti7fq2bfmsli3e0hjvh34.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyBYJly67cRmR972TblBFIJ9DNgGlae8cYc"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "46648411194-jngpfko87lm9edc9f9scig1n6thg1h9j.apps.googleusercontent.com",
-              "client_type": 3
-            },
-            {
-              "client_id": "46648411194-e01krl1j36r8m2frp9v1v9aqs603va2u.apps.googleusercontent.com",
-              "client_type": 2,
-              "ios_info": {
-                "bundle_id": "com.yonatantseitlin.pockertracker"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "client_info": {
         "mobilesdk_app_id": "1:46648411194:android:a4e5ef0a348e9ba7766103",
         "android_client_info": {
           "package_name": "com.yonatantseitlin.pokertracker"
@@ -78,7 +34,7 @@
               "client_id": "46648411194-e01krl1j36r8m2frp9v1v9aqs603va2u.apps.googleusercontent.com",
               "client_type": 2,
               "ios_info": {
-                "bundle_id": "com.yonatantseitlin.pockertracker"
+                "bundle_id": "com.yonatantseitlin.pokertracker"
               }
             }
           ]

--- a/config/google-services.json
+++ b/config/google-services.json
@@ -51,7 +51,7 @@
     },
     {
       "client_info": {
-        "mobilesdk_app_id": "1:46648411194:android:eb974409a0cb5bf0766103",
+        "mobilesdk_app_id": "1:46648411194:android:a4e5ef0a348e9ba7766103",
         "android_client_info": {
           "package_name": "com.yonatantseitlin.pokertracker"
         }


### PR DESCRIPTION
## Summary
- Renamed Android package from `com.yonatantseitlin.pockertracker` to `com.yonatantseitlin.pokertracker`
- Fixed slug in `app.json` from `pocker-tracker` to `poker-tracker`
- Updated both `google-services.json` files to use the correct package name
- Removed old Firebase app entry for the typo'd package name

🤖 Generated with [Claude Code](https://claude.com/claude-code)